### PR TITLE
fix: harden loading-state review followups

### DIFF
--- a/JOBCARD.md
+++ b/JOBCARD.md
@@ -1,6 +1,14 @@
 # JOBCARD
 
-## Latest update (2026-04-10)
+## Latest update (2026-04-13)
+
+- Cleared problem-loading skeleton state before rendering the live problem so stale `dataset.originalContent` snapshots cannot overwrite gameplay content later.
+- Made loading skeleton and spinner capture idempotent in `src/scripts/ux-loading.js` to prevent double-show races from storing spinner markup as the restore target.
+- Tightened `tests/problem-loading.spec.js` to assert both spinner removal and cleanup of the saved original-content dataset entry.
+- Extended `tests/problem-loading.spec.js` again to cover generic loading skeleton and spinner helpers directly, including idempotent restore behavior across repeated show calls.
+- Extended `tests/run-playwright-group.js --check` to verify complete coverage of top-level `tests/*.spec.js` browser lanes while excluding nested unit, integration, and performance suites from split-group scope.
+
+## Previous update (2026-04-10)
 
 - Consolidated the repository to a five-Markdown policy: `.github/copilot-instructions.md`, `JOBCARD.md`, `Plan Genesis.md`, `Plan Beta.md`, and `Plan Alpha.md`.
 - Merged the old README, system docs, worm guides, competition docs, task brief, and superpower planning artifacts into the three surviving plan files based on content ownership.

--- a/src/scripts/game-problem-manager.js
+++ b/src/scripts/game-problem-manager.js
@@ -90,6 +90,8 @@ console.log("📚 Game problem manager module loading...");
       return;
     }
 
+    window.hideProblemLoadingSkeleton?.(problemContainer);
+
     // Reset indices
     currentSolutionStepIndex = 0;
     invalidateStepCache(); // PERFORMANCE: Invalidate cache on new problem

--- a/src/scripts/symbol-rain.config.js
+++ b/src/scripts/symbol-rain.config.js
@@ -33,7 +33,6 @@
     // Face reveal
     faceRevealInterval: 5000,
     faceRevealDuration: 1500,
-    faceRevealBufferMultiplier: 2.5,
     // Layout
     columnWidth: 50,
     gridCellSize: 100,

--- a/src/scripts/ux-loading.js
+++ b/src/scripts/ux-loading.js
@@ -1,8 +1,18 @@
 (function() {
   class LoadingStateManager {
+    static storeOriginalContent(element) {
+      if (!element || element.dataset.originalContent !== undefined) {
+        return false;
+      }
+
+      element.dataset.originalContent = element.innerHTML;
+      return true;
+    }
+
     static showLoadingSkeleton(element, skeletonType = "custom") {
-      const originalContent = element.innerHTML;
-      element.dataset.originalContent = originalContent;
+      if (!this.storeOriginalContent(element)) {
+        return;
+      }
 
       const skeleton = document.createElement("div");
       skeleton.className = `loading-skeleton ${skeletonType}-loading-skeleton`;
@@ -22,6 +32,10 @@
     }
 
     static showLoadingSpinner(element, message = "Loading...") {
+      if (!this.storeOriginalContent(element)) {
+        return;
+      }
+
       const spinner = document.createElement("div");
       spinner.className = "loading-spinner-container";
       spinner.innerHTML = `
@@ -31,7 +45,6 @@
       spinner.setAttribute("role", "status");
       spinner.setAttribute("aria-label", message);
 
-      element.dataset.originalContent = element.innerHTML;
       element.innerHTML = "";
       element.appendChild(spinner);
     }
@@ -44,7 +57,7 @@
       element,
       { level = "problem", problemPath = null, title = null, detail = null } = {},
     ) {
-      if (!element) {
+      if (!this.storeOriginalContent(element)) {
         return;
       }
 
@@ -63,7 +76,6 @@
             ? "Fetching " + problemPath.split("/").pop()
             : "Preparing step targets...";
 
-      element.dataset.originalContent = element.innerHTML;
       element.innerHTML = "";
 
       const container = document.createElement("div");

--- a/tests/problem-loading.spec.js
+++ b/tests/problem-loading.spec.js
@@ -34,5 +34,98 @@ test.describe("Problem loading display", () => {
     await expect(page.locator("#problem-container .problem-text")).toBeVisible({
       timeout: 10000,
     });
+    await expect(loadingCard).toBeHidden({ timeout: 10000 });
+    await expect
+      .poll(async () =>
+        page.locator("#problem-container").evaluate((element) => {
+          return element.dataset.originalContent ?? null;
+        }),
+      )
+      .toBe(null);
+  });
+
+  test("keeps generic loading helpers idempotent until hidden", async ({
+    page,
+  }) => {
+    await gotoGameRuntime(page, "?level=beginner&preload=off");
+    await page.waitForFunction(
+      () => Boolean(window.UXModules?.LoadingStateManager),
+      null,
+      { timeout: 10000 },
+    );
+
+    const skeletonState = await page.evaluate(() => {
+      const host = document.createElement("div");
+      host.id = "loading-helper-test-host";
+      host.innerHTML = "<span>Original skeleton content</span>";
+      document.body.appendChild(host);
+
+      const manager = window.UXModules.LoadingStateManager;
+      manager.showLoadingSkeleton(host, "custom");
+      const firstSnapshot = host.dataset.originalContent ?? null;
+      manager.showLoadingSkeleton(host, "custom");
+      const secondSnapshot = host.dataset.originalContent ?? null;
+      const skeletonCount = host.querySelectorAll(".loading-skeleton").length;
+      manager.hideLoadingSkeleton(host);
+
+      const restoredMarkup = host.innerHTML;
+      const restoredSnapshot = host.dataset.originalContent ?? null;
+      host.remove();
+
+      return {
+        firstSnapshot,
+        secondSnapshot,
+        skeletonCount,
+        restoredMarkup,
+        restoredSnapshot,
+      };
+    });
+
+    expect(skeletonState.firstSnapshot).toContain("Original skeleton content");
+    expect(skeletonState.secondSnapshot).toBe(skeletonState.firstSnapshot);
+    expect(skeletonState.skeletonCount).toBe(1);
+    expect(skeletonState.restoredMarkup).toContain("Original skeleton content");
+    expect(skeletonState.restoredSnapshot).toBe(null);
+
+    const spinnerState = await page.evaluate(() => {
+      const host = document.createElement("div");
+      host.id = "loading-spinner-test-host";
+      host.innerHTML = "<span>Original spinner content</span>";
+      document.body.appendChild(host);
+
+      const manager = window.UXModules.LoadingStateManager;
+      manager.showLoadingSpinner(host, "Loading data...");
+      const firstSnapshot = host.dataset.originalContent ?? null;
+      const firstMessage =
+        host.querySelector(".loading-message")?.textContent ?? null;
+      manager.showLoadingSpinner(host, "Different message should not replace content");
+      const secondSnapshot = host.dataset.originalContent ?? null;
+      const secondMessage =
+        host.querySelector(".loading-message")?.textContent ?? null;
+      const spinnerCount = host.querySelectorAll(".loading-spinner-container").length;
+      manager.hideLoadingSpinner(host);
+
+      const restoredMarkup = host.innerHTML;
+      const restoredSnapshot = host.dataset.originalContent ?? null;
+      host.remove();
+
+      return {
+        firstSnapshot,
+        firstMessage,
+        secondSnapshot,
+        secondMessage,
+        spinnerCount,
+        restoredMarkup,
+        restoredSnapshot,
+      };
+    });
+
+    expect(spinnerState.firstSnapshot).toContain("Original spinner content");
+    expect(spinnerState.firstMessage).toBe("Loading data...");
+    expect(spinnerState.secondSnapshot).toBe(spinnerState.firstSnapshot);
+    expect(spinnerState.secondMessage).toBe("Loading data...");
+    expect(spinnerState.spinnerCount).toBe(1);
+    expect(spinnerState.restoredMarkup).toContain("Original spinner content");
+    expect(spinnerState.restoredSnapshot).toBe(null);
   });
 });

--- a/tests/run-playwright-group.js
+++ b/tests/run-playwright-group.js
@@ -1,6 +1,9 @@
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import { resolve } from "node:path";
 import { spawnSync } from "node:child_process";
+
+const TESTS_DIR = "tests";
+const TOP_LEVEL_SPEC_SUFFIX = ".spec.js";
 
 const GROUPS = Object.freeze({
   boot: [
@@ -77,12 +80,17 @@ function validateGroups() {
   const seen = new Map();
   const duplicates = [];
   const missing = [];
+  const outOfScope = [];
+  const topLevelSpecs = getTopLevelSpecs();
+  const topLevelSpecSet = new Set(topLevelSpecs);
 
   for (const [groupName, specs] of Object.entries(GROUPS)) {
     for (const spec of specs) {
       const absolutePath = resolve(process.cwd(), spec);
       if (!existsSync(absolutePath)) {
         missing.push(groupName + ": " + spec);
+      } else if (!topLevelSpecSet.has(spec)) {
+        outOfScope.push(groupName + ": " + spec);
       }
 
       if (seen.has(spec)) {
@@ -93,17 +101,45 @@ function validateGroups() {
     }
   }
 
-  if (missing.length > 0 || duplicates.length > 0) {
+  const ungrouped = topLevelSpecs.filter((spec) => !seen.has(spec));
+
+  if (
+    missing.length > 0 ||
+    duplicates.length > 0 ||
+    outOfScope.length > 0 ||
+    ungrouped.length > 0
+  ) {
     if (missing.length > 0) {
       console.error("Missing spec files:\n" + missing.join("\n"));
     }
     if (duplicates.length > 0) {
       console.error("Duplicate spec assignments:\n" + duplicates.join("\n"));
     }
+    if (outOfScope.length > 0) {
+      console.error(
+        "Out-of-scope split assignments (expected top-level tests/*.spec.js only):\n" +
+          outOfScope.join("\n"),
+      );
+    }
+    if (ungrouped.length > 0) {
+      console.error(
+        "Ungrouped top-level Playwright specs:\n" + ungrouped.join("\n"),
+      );
+    }
     return false;
   }
 
   return true;
+}
+
+function getTopLevelSpecs() {
+  const testsDir = resolve(process.cwd(), TESTS_DIR);
+  return readdirSync(testsDir, { withFileTypes: true })
+    .filter(
+      (entry) => entry.isFile() && entry.name.endsWith(TOP_LEVEL_SPEC_SUFFIX),
+    )
+    .map((entry) => TESTS_DIR + "/" + entry.name)
+    .sort();
 }
 
 function printGroups() {


### PR DESCRIPTION
## Summary
- clear problem-loading skeleton state before rendering live problem content and make loading-state capture idempotent
- strengthen focused loading coverage for skeleton cleanup and generic loading helpers
- tighten split Playwright group validation for top-level browser-lane specs and update the job log

## Test Plan
- [x] npm run verify
- [x] npm run typecheck
- [x] npx playwright test tests/problem-loading.spec.js --reporter=line

## Summary by Sourcery

Harden loading-state handling for problem pages and enforce stricter Playwright spec grouping validation.

Bug Fixes:
- Prevent stale loading skeleton state from restoring over live problem content when new problems are loaded.

Enhancements:
- Make generic loading skeleton, spinner, and problem-loading helpers idempotent by centralizing original-content capture.
- Hide the problem loading skeleton when a new problem is rendered to ensure a clean transition between loading and gameplay views.
- Tighten Playwright split-group validation to only allow top-level tests/*.spec.js entries and flag ungrouped specs.

Documentation:
- Update JOBCARD with notes on loading-state fixes, new tests, and Playwright group validation changes.

Tests:
- Extend problem-loading Playwright tests to verify skeleton removal, cleanup of stored original content, and idempotent behavior of generic loading helpers.