### PR TITLE
test(evan): share inactive wait helper

### DIFF
--- a/tests/onboarding-gates.spec.js
+++ b/tests/onboarding-gates.spec.js
@@ -5,6 +5,7 @@ import {
   resetOnboardingState,
   seedOnboardingState,
   setCorruptOnboardingState,
+  waitForEvanToStayInactive,
   waitForGameplayReady,
 } from "./utils/onboarding-runtime.js";
 
@@ -95,6 +96,60 @@ test.describe("Onboarding gates — Build 1", () => {
       timeout: 5000,
     });
     expect(await page.evaluate(() => window.__evanStartCount)).toBe(1);
+  });
+
+  test("waitForEvanToStayInactive waits through delayed Evan activation", async ({
+    page,
+  }) => {
+    await seedOnboardingState(
+      page,
+      {
+        version: 1,
+        sessionCount: 1,
+        evanConsumed: { beginner: true, warrior: false, master: false },
+        installPromptDismissedAt: null,
+        updatedAt: 0,
+      },
+      "?level=beginner&evan=auto&preload=off",
+    );
+    await dismissBriefingAndWaitForInteractiveGameplay(page);
+    await page.waitForSelector("#evan-solve-button", {
+      state: "visible",
+      timeout: 5000,
+    });
+
+    await page.evaluate(() => {
+      setTimeout(() => {
+        document.getElementById("evan-solve-button")?.click();
+      }, 150);
+    });
+
+    await waitForEvanToStayInactive(page);
+
+    const state = await page.evaluate(() => {
+      const isVisible = (id) => {
+        const element = document.getElementById(id);
+        return Boolean(
+          element &&
+            !element.hidden &&
+            window.getComputedStyle(element).display !== "none",
+        );
+      };
+
+      return {
+        evanHelpActive: document.body.classList.contains("evan-help-active"),
+        evanInputLocked: document.body.classList.contains("evan-input-locked"),
+        skipVisible: isVisible("evan-skip-button"),
+        stopVisible: isVisible("evan-stop-button"),
+      };
+    });
+
+    expect(state).toEqual({
+      evanHelpActive: false,
+      evanInputLocked: false,
+      skipVisible: false,
+      stopVisible: false,
+    });
   });
 
   test("session counter increments on each page load", async ({ page }) => {

--- a/tests/utils/onboarding-runtime.js
+++ b/tests/utils/onboarding-runtime.js
@@ -189,6 +189,54 @@ export async function stopEvanHelpIfActive(page) {
   );
 }
 
+export async function waitForEvanToStayInactive(page, options = {}) {
+  const stableForMs = options.stableForMs ?? 300;
+  const timeout = options.timeout ?? 5000;
+  const pollIntervalMs = options.pollIntervalMs ?? 50;
+  const deadline = Date.now() + timeout;
+  let inactiveSince = null;
+
+  while (Date.now() < deadline) {
+    const state = await page.evaluate(() => {
+      const skipButton = document.getElementById("evan-skip-button");
+      const stopButton = document.getElementById("evan-stop-button");
+      const isVisible = (element) =>
+        Boolean(
+          element &&
+            !element.hidden &&
+            window.getComputedStyle(element).display !== "none",
+        );
+
+      return {
+        evanHelpActive: document.body.classList.contains("evan-help-active"),
+        evanInputLocked: document.body.classList.contains("evan-input-locked"),
+        skipVisible: isVisible(skipButton),
+        stopVisible: isVisible(stopButton),
+      };
+    });
+
+    if (state.skipVisible) {
+      await page.click("#evan-skip-button");
+      inactiveSince = null;
+    } else if (state.stopVisible) {
+      await page.click("#evan-stop-button");
+      inactiveSince = null;
+    } else if (!state.evanHelpActive && !state.evanInputLocked) {
+      if (inactiveSince === null) {
+        inactiveSince = Date.now();
+      } else if (Date.now() - inactiveSince >= stableForMs) {
+        return;
+      }
+    } else {
+      inactiveSince = null;
+    }
+
+    await page.waitForTimeout(pollIntervalMs);
+  }
+
+  throw new Error(`Timed out waiting for Evan to stay inactive after ${timeout}ms`);
+}
+
 export async function dismissBriefingAndWaitForInteractiveGameplay(page) {
   await waitForOnboardingRuntime(page);
   await ensureLandscapeGameplayViewport(page);

--- a/tests/worm-cursor-evasion.spec.js
+++ b/tests/worm-cursor-evasion.spec.js
@@ -4,6 +4,7 @@ import {
   dismissBriefingAndWaitForInteractiveGameplay,
   resetOnboardingState,
   stopEvanHelpIfActive,
+  waitForEvanToStayInactive,
 } from "./utils/onboarding-runtime.js";
 
 test.describe("Worm cursor evasion", () => {
@@ -15,6 +16,7 @@ test.describe("Worm cursor evasion", () => {
     await page.waitForFunction(
       () => window.wormSystem && window.wormSystem.isInitialized === true,
     );
+    await waitForEvanToStayInactive(page);
   });
 
   test("worms move away from cursor threat", async ({ page }) => {
@@ -28,17 +30,22 @@ test.describe("Worm cursor evasion", () => {
 
     const initial = await page.evaluate(() => {
       const worm = window.wormSystem.worms.find((w) => w.active && !w.isPurple);
-      return worm ? { x: worm.x, y: worm.y } : null;
+      return worm ? { id: worm.id, x: worm.x, y: worm.y } : null;
     });
 
     expect(initial).toBeTruthy();
 
-    await page.evaluate((wormPos) => {
+    const threatPoint = {
+      x: initial.x + 10,
+      y: initial.y + 10,
+    };
+
+    await page.evaluate((point) => {
       document.dispatchEvent(
         new CustomEvent("wormCursorUpdate", {
           detail: {
-            x: wormPos.x + 10,
-            y: wormPos.y + 10,
+            x: point.x,
+            y: point.y,
             isActive: true,
             pointerType: "mouse",
             lastUpdate: performance.now(),
@@ -46,24 +53,45 @@ test.describe("Worm cursor evasion", () => {
           },
         }),
       );
-    }, initial);
+    }, threatPoint);
 
-    await page.waitForTimeout(200);
+    await page.waitForFunction(
+      ({ wormId, threatX, threatY, minimumDistance }) => {
+        const worm = window.wormSystem.worms.find((w) => w.id === wormId);
+        if (!worm || !worm.active) {
+          return false;
+        }
 
-    const after = await page.evaluate(() => {
-      const worm = window.wormSystem.worms.find((w) => w.active && !w.isPurple);
-      return worm ? { x: worm.x, y: worm.y } : null;
-    });
+        return (
+          Math.hypot(worm.x - threatX, worm.y - threatY) > minimumDistance
+        );
+      },
+      {
+        wormId: initial.id,
+        threatX: threatPoint.x,
+        threatY: threatPoint.y,
+        minimumDistance: Math.hypot(
+          initial.x - threatPoint.x,
+          initial.y - threatPoint.y,
+        ),
+      },
+      { timeout: 3000 },
+    );
+
+    const after = await page.evaluate((wormId) => {
+      const worm = window.wormSystem.worms.find((w) => w.id === wormId);
+      return worm && worm.active ? { x: worm.x, y: worm.y } : null;
+    }, initial.id);
 
     expect(after).toBeTruthy();
 
     const initialDistance = Math.hypot(
-      initial.x - (initial.x + 10),
-      initial.y - (initial.y + 10),
+      initial.x - threatPoint.x,
+      initial.y - threatPoint.y,
     );
     const newDistance = Math.hypot(
-      after.x - (initial.x + 10),
-      after.y - (initial.y + 10),
+      after.x - threatPoint.x,
+      after.y - threatPoint.y,
     );
 
     expect(newDistance).toBeGreaterThan(initialDistance);


### PR DESCRIPTION
## Summary
- add a shared Playwright helper to wait for Evan to stay inactive
- cover delayed Evan activation in onboarding gates
- migrate worm cursor evasion to the shared helper while preserving worm identity-based assertions

## Testing
- npm test -- tests/onboarding-gates.spec.js -g "waitForEvanToStayInactive waits through delayed Evan activation"
- npx playwright test tests/worm-cursor-evasion.spec.js --project=chromium --repeat-each=5
- npm test -- tests/worm-cursor-evasion.spec.js
- npm run verify
- npm run typecheck

## Summary by Sourcery

Introduce a shared helper to ensure Evan help remains inactive and apply it across relevant onboarding tests.

New Features:
- Add a reusable waitForEvanToStayInactive Playwright helper for asserting Evan help remains inactive.

Enhancements:
- Cover delayed Evan activation behaviour in onboarding gates tests.
- Improve worm cursor evasion test to track a specific worm by id and wait for distance-based evasion instead of relying on fixed timeouts.

Tests:
- Add a dedicated test verifying waitForEvanToStayInactive handles delayed Evan activation and update worm cursor evasion tests to use the new helper and more robust assertions.