### PR TITLE
fix(ci): scope Playwright channel to chromium projects; install webkit in nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,8 +178,9 @@ jobs:
           restore-keys: |
             playwright-${{ runner.os }}-
       - name: Install Playwright browsers
-        # iphone-13 / pixel-7 are chromium device-emulation projects; chromium binary covers all three.
-        run: npx playwright install --with-deps chromium
+        # Full default matrix covers chromium (chromium/pixel-7 projects) AND
+        # webkit (iphone-13 project — Device "iPhone 13" is WebKit). Install both.
+        run: npx playwright install --with-deps chromium webkit
       - name: Playwright full default matrix
         # CLI --workers overrides the config's CI workers:1 for the nightly batch.
         run: npx playwright test --workers=2

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,5 +1,18 @@
-// @ts-check
+/** @ts-check */
 import { defineConfig, devices } from "@playwright/test";
+
+// Chromium-only launch hardening. chrome-headless-shell segfaults intermittently
+// (signal 11 SEGV_MAPERR) on some kernels; the full Chromium in new headless mode
+// (channel: "chromium") is the documented stable workaround. Scoped to chromium
+// projects only — the webkit project (iphone-13 / Device "iPhone 13") must NOT
+// inherit channel: "chromium" (Playwright throws
+// "Unsupported webkit channel \"chromium\"").
+const chromiumLaunch = {
+  launchOptions: {
+    args: ["--disable-dev-shm-usage"],
+  },
+  channel: "chromium",
+};
 
 const cliArgs = process.argv.slice(2).join(" ");
 const shouldSerializeLocalIphonePerfLane =
@@ -50,22 +63,13 @@ export default defineConfig({
     screenshot: "only-on-failure",
     /* Enable test hooks for debugging */
     testIdAttribute: "data-testid",
-    /* Chromium crashes (SIGSEGV on newContext) on CI runners with small /dev/shm.
-       Disable the shm-backed ramfs and use /tmp instead. Harmless on dev machines. */
-    launchOptions: {
-      args: ["--disable-dev-shm-usage"],
-    },
-    /* Use the full Chromium in new headless mode instead of chrome-headless-shell.
-       chrome-headless-shell segfaults intermittently (signal 11 SEGV_MAPERR) on some
-       kernels; the full chromium channel is the documented stable workaround. */
-    channel: "chromium",
   },
 
   /* Configure projects for major browsers */
   projects: [
     {
       name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
+      use: { ...devices["Desktop Chrome"], ...chromiumLaunch },
     },
     {
       name: "iphone-13",
@@ -77,7 +81,7 @@ export default defineConfig({
     },
     {
       name: "pixel-7",
-      use: { ...devices["Pixel 7"] },
+      use: { ...devices["Pixel 7"], ...chromiumLaunch },
     },
   ],
 


### PR DESCRIPTION
## Root cause
The nightly full-matrix e2e (`e2e-nightly`) has been RED on every scheduled run (e.g. run `29717035029`) since the dependabot Playwright bump, with:
```
Error: browserType.launch: Unsupported webkit channel "chromium"
```

`playwright.config.js` set `channel: "chromium"` AND `launchOptions.args:['--disable-dev-shm-usage']` in the **global** `use` block. The `iphone-13` project uses `devices["iPhone 13"]`, which is **WebKit** — WebKit rejects both the chromium channel and the `--disable-dev-shm-usage` flag. The fast PR gate only runs `--project=chromium`, so the bug was invisible on PRs and only blew up in the nightly full matrix.

## Fix
Mirror the already-correct pattern from `playwright.competition.config.js`: define a `chromiumLaunch` object (`channel:"chromium"` + dev-shm arg) and spread it only into the `chromium` and `pixel-7` projects. The webkit `iphone-13` project no longer inherits either.

Also install `webkit` in the nightly job (the matrix covers a WebKit project; `chromium` binary alone does not cover it).

## Verification (local, fresh npm ci from main lock)
- `npm run lint` → 0 errors (4 warnings, pre-existing)
- `npm run typecheck` → clean
- `npx playwright test --project=chromium --project=iphone-13 --project=pixel-7 tests/tutorial-problem-loader.spec.js` → **3 passed** (previously the iphone-13/webkit launch crashed)

Note: the nightly job is schedule-only and is NOT a required status check, so this does not block merges — but it makes the nightly actually pass going forward.

@TeacherEvan for review/approval.

## Summary by Sourcery

Scope Playwright’s Chromium-specific launch settings to Chromium-based projects only and ensure the nightly CI matrix installs the required WebKit browser.

Bug Fixes:
- Prevent WebKit-based iphone-13 tests from failing by no longer inheriting Chromium-only launch options and channel configuration.
- Fix nightly e2e runs by installing the WebKit browser in addition to Chromium in the CI workflow.

Enhancements:
- Introduce a shared Chromium launch configuration reused across Chromium-oriented Playwright projects (chromium and pixel-7).

CI:
- Update the nightly Playwright installation step to install both Chromium and WebKit browsers for the full test matrix.