### PR TITLE
test: malformed-state regression guards for entry-flow surfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,8 @@ audit_report.md
 review_findings.md
 fix_summary.md
 investigation_report.md
+
+# Hermes plan/audit analyzer artifacts (advisory, not project source)
+HERMES_PLAN.ai.json
+HERMES_PLAN.html
+docs/.scratch-audit/*.html

--- a/JOBCARD.md
+++ b/JOBCARD.md
@@ -1,5 +1,13 @@
 # JOBCARD
 
+## Audit closure (2026-08-20)
+
+- Ran the surgical-implementation dispatcher scan: found `HERMES_PLAN.ai.json` (`status: proposed`, generated 2026-08-15, after the last code commit 2026-08-01) plus the durable `Plan Alpha.md` / `Plan Beta.md` / `Plan Genesis.md` / `JOBCARD.md`. The Hermes plan is a post-hoc snapshot with no approval ticks, so it was treated as advisory, not an implementation authorization.
+- Audited `Plan Beta.md` "Entry Flow Hardening" track (4 workstreams, all `[ ]`): empirically verified each surface rather than trusting the unchecked boxes. Confirmed the defensive storage/redirect/startup contracts were already shipped in the 2026-05-06 hardening slice (`safeParse` + `migrateProfile` in `player-storage.js`/`player-storage.helpers.js`, graceful `redirect-entrypoint.js` query/hash forwarding, and `startup-preload.js` degradation with `try/catch`).
+- Closed the plan's missing regression coverage by adding `pageerror` assertions for malformed persisted state (invalid JSON, non-object JSON, malformed recent-history, corrupted settings/onboarding) to `tests/welcome-scoreboard.spec.js`, `tests/level-select-interactions.spec.js`, `tests/redirect-entrypoints.spec.js`, and `tests/startup-preload.spec.js` — no source change was needed because the runtime already degrades safely.
+- Verified the entry-flow batch: `npx playwright test tests/welcome-scoreboard.spec.js tests/level-select-interactions.spec.js tests/redirect-entrypoints.spec.js tests/startup-preload.spec.js --project=chromium --reporter=line` → 44 passed (incl. 6 new malformed-state tests). `npm run verify` 6/6, `npm run typecheck` clean, ESLint clean on touched specs.
+- Decision: the Entry Flow Hardening track's runtime work is complete; only the durable checkbox ticks + this log remained. Left the plan's `[ ]` boxes as found (awaiting user sign-off before flipping status banners), per the repository rule that code state decides, not the banner.
+
 ## Latest update (2026-05-06)
 
 - Hardened shared player-profile normalization so oversized persisted player names are clamped during profile migration instead of only on manual save, which keeps welcome and level-select scoreboard consumers on the same bounded storage contract.

--- a/tests/level-select-interactions.spec.js
+++ b/tests/level-select-interactions.spec.js
@@ -352,4 +352,35 @@ test.describe("Level select interactions", () => {
       await expect(page).toHaveURL(/\/src\/pages\/index\.html(?:$|\?)/);
     });
   }
+
+  test("renders without uncaught errors when persisted profile and settings are malformed", async ({
+    page,
+  }) => {
+    const errors = [];
+    page.on("pageerror", (error) => errors.push(error.message));
+
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "mathmaster_player_profile_v1",
+        "{ not valid json ",
+      );
+      localStorage.setItem(
+        "mathmaster_user_settings_v1",
+        "corrupted-string",
+      );
+      localStorage.setItem(
+        "mathmaster_onboarding_v1",
+        JSON.stringify(42),
+      );
+    });
+
+    await useDesktopViewport(page);
+    await page.goto(LEVEL_SELECT_URL, { waitUntil: "domcontentloaded" });
+    await waitForCardsToSettle(page);
+
+    const runButton = page.getByRole("button", { name: "Run foundations" });
+    await expect(runButton).toBeVisible();
+
+    expect(errors).toEqual([]);
+  });
 });

--- a/tests/redirect-entrypoints.spec.js
+++ b/tests/redirect-entrypoints.spec.js
@@ -28,4 +28,32 @@ test.describe("root redirect entrypoints", () => {
       await expect(page).toHaveURL(redirectCase.expected);
     });
   }
+
+  test("preserves query and hash while forwarding from a malformed seeded state", async ({
+    page,
+  }) => {
+    const errors = [];
+    page.on("pageerror", (error) => errors.push(error.message));
+
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "mathmaster_player_profile_v1",
+        "{ not valid json ",
+      );
+      localStorage.setItem(
+        "mathmaster_onboarding_v1",
+        "corrupted-string",
+      );
+    });
+
+    await page.goto("/index.html?welcome=returning#scoreboard", {
+      waitUntil: "domcontentloaded",
+    });
+
+    await expect(page).toHaveURL(
+      /\/src\/pages\/index\.html\?welcome=returning#scoreboard$/,
+    );
+
+    expect(errors).toEqual([]);
+  });
 });

--- a/tests/startup-preload.spec.js
+++ b/tests/startup-preload.spec.js
@@ -572,4 +572,35 @@ test.describe("Startup Preload — Build 2", () => {
         queuedLevels: ["warrior", "master"],
       });
   });
+
+  test("reaches a fallback-ready state without uncaught errors under malformed stored state", async ({
+    page,
+  }) => {
+    const errors = [];
+    page.on("pageerror", (error) => errors.push(error.message));
+
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "mathmaster_player_profile_v1",
+        "{ not valid json ",
+      );
+      localStorage.setItem(
+        "mathmaster_user_settings_v1",
+        "corrupted-string",
+      );
+      localStorage.setItem(
+        "mathmaster_onboarding_v1",
+        JSON.stringify(42),
+      );
+      localStorage.setItem("mathmaster_audio_pref_v1", "{ broken ");
+    });
+
+    await gotoGameRuntime(page, "?level=beginner&preload=off");
+    await waitForStartupPreload(page);
+    await waitForBriefingVisible(page, 3000);
+
+    await expect(page.locator("#start-game-btn")).toBeVisible();
+
+    expect(errors).toEqual([]);
+  });
 });

--- a/tests/welcome-scoreboard.spec.js
+++ b/tests/welcome-scoreboard.spec.js
@@ -233,4 +233,89 @@ test.describe("Welcome scoreboard", () => {
     );
     expect(scoreBox.y).toBeGreaterThanOrEqual(historyBox.y + 18);
   });
+
+  test("renders without uncaught errors when the stored profile is malformed JSON", async ({
+    page,
+  }) => {
+    const errors = [];
+    page.on("pageerror", (error) => errors.push(error.message));
+
+    await page.addInitScript((storageKey) => {
+      localStorage.setItem(storageKey, "{ this is not valid json ");
+    }, PROFILE_KEY);
+
+    await page.goto("/src/pages/index.html");
+    await page.locator("#scoreboard-button").click({
+      force: true,
+      noWaitAfter: true,
+    });
+
+    await expect(page.locator("#scoreboard-modal")).toBeVisible();
+    await expect(page.locator("#scoreboard-player-name")).toBeVisible();
+
+    expect(errors).toEqual([]);
+  });
+
+  test("renders without uncaught errors when the stored profile is valid JSON but not an object", async ({
+    page,
+  }) => {
+    const errors = [];
+    page.on("pageerror", (error) => errors.push(error.message));
+
+    await page.addInitScript((storageKey) => {
+      localStorage.setItem(storageKey, JSON.stringify("corrupted-string"));
+    }, PROFILE_KEY);
+
+    await page.goto("/src/pages/index.html");
+    await page.locator("#scoreboard-button").click({
+      force: true,
+      noWaitAfter: true,
+    });
+
+    await expect(page.locator("#scoreboard-modal")).toBeVisible();
+    await expect(page.locator("#scoreboard-player-name")).toBeVisible();
+
+    expect(errors).toEqual([]);
+  });
+
+  test("renders without uncaught errors when recent history entries are malformed", async ({
+    page,
+  }) => {
+    const errors = [];
+    page.on("pageerror", (error) => errors.push(error.message));
+
+    await page.addInitScript((storageKey) => {
+      localStorage.setItem(
+        storageKey,
+        JSON.stringify({
+          version: 3,
+          name: "Neo",
+          levels: {},
+          recentHistory: [
+            { levelKey: "beginner", score: 100, completedAt: 1735689600000 },
+            { levelKey: 42, score: "broken", completedAt: "nope" },
+            "garbage",
+            null,
+          ],
+          overall: {
+            totalScore: 100,
+            problemsCompleted: 1,
+            lastPlayed: 1735689600000,
+          },
+          updatedAt: 1735689600000,
+        }),
+      );
+    }, PROFILE_KEY);
+
+    await page.goto("/src/pages/index.html");
+    await page.locator("#scoreboard-button").click({
+      force: true,
+      noWaitAfter: true,
+    });
+
+    await expect(page.locator("#scoreboard-modal")).toBeVisible();
+    await expect(page.locator("#scoreboard-history-list")).toBeVisible();
+
+    expect(errors).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary
Adds `pageerror`-guarded Playwright regression tests that lock the runtime's safe-degradation contract when persisted localStorage is corrupt.

- `tests/welcome-scoreboard.spec.js` — invalid JSON, valid-but-string JSON, malformed `recentHistory` array
- `tests/level-select-interactions.spec.js` — malformed profile + settings + onboarding
- `tests/redirect-entrypoints.spec.js` — query/hash preserved while forwarding from malformed seeded state
- `tests/startup-preload.spec.js` — fallback-ready under malformed profile/settings/onboarding/audio

No source change — `safeParse`/`migrateProfile` in `player-storage.js` already degrade safely; these tests prevent regression. Also adds `.gitignore` rules for Hermes plan/audit analyzer artifacts and a `JOBCARD.md` audit-closure note.

## Verification
- Entry-flow batch: `npx playwright test tests/welcome-scoreboard.spec.js tests/level-select-interactions.spec.js tests/redirect-entrypoints.spec.js tests/startup-preload.spec.js --project=chromium` → **44 passed** (incl. 6 new malformed-state tests)
- Full chromium suite: **320 passed / 3 failed / 19 skipped** (18.9m)
- The 3 failures are **pre-existing and unrelated** (verified on clean tree with this branch's changes stashed): `performance-bench.spec.js:115` (fps budget gate), `symbol-rain.mobile.spec.js:653` (Android WebView sim), `welcome-page-redesign.spec.js:9` (hero render). None touch the changed specs.
- `npm run verify` 6/6 · `npm run typecheck` clean · ESLint clean on touched specs.

## Test plan
- [ ] CI runs full suite — confirm the 3 known failures are unchanged and no new failures appear
- [ ] Merge to `main` once green

🤖 Generated with [Hermes](https://hermes-agent.nousresearch.com)

## Summary by Sourcery

Strengthen entry-flow regression coverage for corrupted persisted state without changing runtime behavior.

Enhancements:
- Add Playwright regression coverage confirming entry-flow surfaces safely degrade when persisted profile, settings, onboarding, audio, or history data is malformed.
- Verify root redirects preserve query strings and hash fragments when seeded with corrupted persisted state.

Documentation:
- Record the audit closure and verification results for the entry-flow hardening work.

Tests:
- Add page-error-guarded regression tests for welcome scoreboard, level selection, redirects, and startup preload under malformed localStorage state.

Chores:
- Ignore Hermes plan and audit analyzer artifacts.