### PR TITLE
fix(tests): remove duplicate waitForEvanToStayInactive declaration breaking E2E gate

### DIFF
--- a/tests/utils/onboarding-runtime.js
+++ b/tests/utils/onboarding-runtime.js
@@ -244,54 +244,6 @@ export async function waitForEvanToStayInactive(page, options = {}) {
   throw new Error(`Timed out waiting for Evan to stay inactive after ${timeout}ms`);
 }
 
-export async function waitForEvanToStayInactive(page, options = {}) {
-  const stableForMs = options.stableForMs ?? 300;
-  const timeout = options.timeout ?? 5000;
-  const pollIntervalMs = options.pollIntervalMs ?? 50;
-  const deadline = Date.now() + timeout;
-  let inactiveSince = null;
-
-  while (Date.now() < deadline) {
-    const state = await page.evaluate(() => {
-      const skipButton = document.getElementById("evan-skip-button");
-      const stopButton = document.getElementById("evan-stop-button");
-      const isVisible = (element) =>
-        Boolean(
-          element &&
-            !element.hidden &&
-            window.getComputedStyle(element).display !== "none",
-        );
-
-      return {
-        evanHelpActive: document.body.classList.contains("evan-help-active"),
-        evanInputLocked: document.body.classList.contains("evan-input-locked"),
-        skipVisible: isVisible(skipButton),
-        stopVisible: isVisible(stopButton),
-      };
-    });
-
-    if (state.skipVisible) {
-      await page.click("#evan-skip-button");
-      inactiveSince = null;
-    } else if (state.stopVisible) {
-      await page.click("#evan-stop-button");
-      inactiveSince = null;
-    } else if (!state.evanHelpActive && !state.evanInputLocked) {
-      if (inactiveSince === null) {
-        inactiveSince = Date.now();
-      } else if (Date.now() - inactiveSince >= stableForMs) {
-        return;
-      }
-    } else {
-      inactiveSince = null;
-    }
-
-    await page.waitForTimeout(pollIntervalMs);
-  }
-
-  throw new Error(`Timed out waiting for Evan to stay inactive after ${timeout}ms`);
-}
-
 export async function dismissBriefingAndWaitForInteractiveGameplay(page) {
   await waitForOnboardingRuntime(page);
   await ensureLandscapeGameplayViewport(page);


### PR DESCRIPTION
## Root cause
`tests/utils/onboarding-runtime.js` declared `waitForEvanToStayInactive` **twice** (lines 195 and 247 — byte-for-byte identical). This is a `SyntaxError` that fails the entire Playwright E2E gate at module load, so **every** test file importing this helper crashes before running.

`origin/main` CI has been **red for the last 3 runs** (`32328623065`, `32212524019`, `32095815670`) because of this. Any PR branched from main inherits the break — e.g. #86 could not go green despite its own specs passing.

## Fix
Delete the second (duplicate) function copy. Keeps the first declaration; `dismissBriefingAndWaitForInteractiveGameplay` and all other exports are untouched.

## Verification (local)
- `grep -c "export async function waitForEvanToStayInactive"` → **1**
- `node --check tests/utils/onboarding-runtime.js` → passes
- `npx eslint tests/utils/onboarding-runtime.js` → exit 0

## Impact
- Unblocks the E2E gate for `main` and for #86 (which should re-run green once this merges).
- No behavior change — the removed copy was a redundant duplicate.

## Test plan
- [ ] CI E2E gate goes green on this branch
- [ ] Merge to `main`, then re-run #86 to confirm it clears

🤖 Generated with [Hermes](https://hermes-agent.nousresearch.com)

## Summary by Sourcery

Bug Fixes:
- Remove the duplicate `waitForEvanToStayInactive` declaration so the onboarding runtime module loads successfully and the Playwright E2E gate can run.